### PR TITLE
🔧 chore(auth.config): GoogleとGitHubのProviderにallowLinkAccount追加

### DIFF
--- a/nextjs/auth.config.ts
+++ b/nextjs/auth.config.ts
@@ -12,10 +12,12 @@ export default {
         Google({
             clientId: process.env.GOOGLE_CLIENT_ID,
             clientSecret: process.env.GOOGLE_CLIENT_SECRET,
+            allowDangerousEmailAccountLinking: true,
         }),
         GitHub({
             clientId: process.env.GITHUB_CLIENT_ID,
             clientSecret: process.env.GITHUB_CLIENT_SECRET,
+            allowDangerousEmailAccountLinking: true,
         }),
         Credentials({
             async authorize(credentials) {

--- a/nextjs/auth.ts
+++ b/nextjs/auth.ts
@@ -47,10 +47,6 @@ export const {
             if (existingUser.isTwoFactorEnabled) {
                 const twoFactorTokenConfirmation = await getTwoFactorConfirmationByUserId(existingUser.id);
 
-                console.log({
-                    twoFactorTokenConfirmation
-                });
-
                 if (!twoFactorTokenConfirmation) {
                     return false;
                 }

--- a/nextjs/package-lock.json
+++ b/nextjs/package-lock.json
@@ -1,12 +1,13 @@
 {
-  "name": "demo-next-js",
+  "name": "calmendar",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "demo-next-js",
+      "name": "calmendar",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@auth/prisma-adapter": "^2.4.2",
         "@hookform/resolvers": "^3.9.0",


### PR DESCRIPTION
🔧 chore(package-lock): パッケージ名を 'calmendar' に更新する

🔧 chore(auth.config): GoogleとGitHubの設定にallowLinkAccount追加